### PR TITLE
Zernike array coordinate definition

### DIFF
--- a/aotools/functions/zernike.py
+++ b/aotools/functions/zernike.py
@@ -55,8 +55,9 @@ def zernike_nm(n, m, N):
      Returns:
         ndarray: The Zernike mode
      """
-    coords = numpy.linspace(-1, 1, N)
-    X,Y = numpy.meshgrid(coords, coords)
+    # coords = numpy.linspace(-1.1, 1.1, N)
+    coords = (numpy.arange(N) - N / 2. + 0.5) / (N / 2.)
+    X, Y = numpy.meshgrid(coords, coords)
     R = numpy.sqrt(X**2 + Y**2)
     theta = numpy.arctan2(Y, X)
 

--- a/aotools/functions/zernike.py
+++ b/aotools/functions/zernike.py
@@ -55,7 +55,6 @@ def zernike_nm(n, m, N):
      Returns:
         ndarray: The Zernike mode
      """
-    # coords = numpy.linspace(-1.1, 1.1, N)
     coords = (numpy.arange(N) - N / 2. + 0.5) / (N / 2.)
     X, Y = numpy.meshgrid(coords, coords)
     R = numpy.sqrt(X**2 + Y**2)

--- a/aotools/functions/zernike.py
+++ b/aotools/functions/zernike.py
@@ -89,10 +89,14 @@ def zernikeRadialFunc(n, m, r):
     """
 
     R = numpy.zeros(r.shape)
-    for i in xrange(0,int((n-m)/2)+1):
+    for i in xrange(0, int((n - m) / 2) + 1):
 
-        R += r**(n-2*i) * (((-1)**(i))*numpy.math.factorial(n-i)) / ( numpy.math.factorial(i) * numpy.math.factorial(0.5*(n+m)-i) * numpy.math.factorial(0.5*(n-m)-i) )
-
+        R += numpy.array(r**(n - 2 * i) * (((-1)**(i)) *
+                         numpy.math.factorial(n - i)) /
+                         (numpy.math.factorial(i) *
+                          numpy.math.factorial(0.5 * (n + m) - i) *
+                          numpy.math.factorial(0.5 * (n - m) - i)),
+                         dtype='float')
     return R
 
 

--- a/test/test_zernike.py
+++ b/test/test_zernike.py
@@ -20,6 +20,9 @@ def test_zenikeRadialFunc():
     r = numpy.sqrt(x ** 2 + y ** 2)
 
     radial_function = functions.zernikeRadialFunc(5, 3, r)
+    # test no casting error for high order modes
+    _ = functions.zernikeRadialFunc(21, 1, r)
+    _ = functions.zernikeRadialFunc(50, 16, r)
     assert(radial_function.shape == (32, 32))
 
 


### PR DESCRIPTION
This modification makes the coordinate grid consistent between Zernike and circle (also used by Soapy for pupil definition).
Difference in 'pupil' definition is minor so I expect it should have a minor impact but I haven't tested its effects extensively...
If, on the other hand, there is a reason to have different coordinate grids (ie to reject this PR), I would be happy to know.
