### PR TITLE
Adding option to centroider centerOfGravity

### DIFF
--- a/aotools/image_processing/centroiders.py
+++ b/aotools/image_processing/centroiders.py
@@ -58,9 +58,13 @@ def centreOfGravity(img, threshold=0, minThreshold=0, **kwargs):
     Sets all values under "threshold*max_value" to zero before centroiding
     Origin at 0,0 index of img.
 
+    The value under which pixels are set to 0
+     is max(threshold*max_value, minThreshold)
+
     Parameters:
         img (ndarray): ([n, ]y, x) 2d or greater rank array of imgs to centroid
         threshold (float): Percentage of max value under which pixels set to 0
+        minThreshold (float): Absolute max value under which pixels set to 0
 
     Returns:
         ndarray: Array of centroid values (2[, n])

--- a/aotools/image_processing/centroiders.py
+++ b/aotools/image_processing/centroiders.py
@@ -70,11 +70,9 @@ def centreOfGravity(img, threshold=0, minThreshold=0, **kwargs):
     if threshold != 0:
         if len(img.shape) == 2:
             thres = numpy.max((threshold*img.max(), minThreshold))
-            #img = numpy.where(img > threshold*img.max(), img - threshold*img.max(), 0)
             img = numpy.where(img > thres, img - thres, 0)
         else:
             thres = numpy.maximum(threshold*img.max(-1).max(-1), [minThreshold]*img.shape[0])
-            #img_temp = (img.T - threshold*img.max(-1).max(-1)).T
             img_temp = (img.T - thres).T
             zero_coords = numpy.where(img_temp < 0)
             img[zero_coords] = 0

--- a/aotools/image_processing/centroiders.py
+++ b/aotools/image_processing/centroiders.py
@@ -51,7 +51,7 @@ def correlation_centroid(im, ref, threshold=0., padding=1):
     return centroids
 
 
-def centreOfGravity(img, threshold=0, **kwargs):
+def centreOfGravity(img, threshold=0, minThreshold=0, **kwargs):
     """
     Centroids an image, or an array of images.
     Centroids over the last 2 dimensions.
@@ -66,11 +66,16 @@ def centreOfGravity(img, threshold=0, **kwargs):
         ndarray: Array of centroid values (2[, n])
 
     """
+
     if threshold != 0:
         if len(img.shape) == 2:
-            img = numpy.where(img > threshold*img.max(), img - threshold*img.max(), 0)
+            thres = numpy.max((threshold*img.max(), minThreshold))
+            #img = numpy.where(img > threshold*img.max(), img - threshold*img.max(), 0)
+            img = numpy.where(img > thres, img - thres, 0)
         else:
-            img_temp = (img.T - threshold*img.max(-1).max(-1)).T
+            thres = numpy.maximum(threshold*img.max(-1).max(-1), [minThreshold]*img.shape[0])
+            #img_temp = (img.T - threshold*img.max(-1).max(-1)).T
+            img_temp = (img.T - thres).T
             zero_coords = numpy.where(img_temp < 0)
             img[zero_coords] = 0
 

--- a/aotools/image_processing/centroiders.py
+++ b/aotools/image_processing/centroiders.py
@@ -68,7 +68,7 @@ def centreOfGravity(img, threshold=0, **kwargs):
     """
     if threshold != 0:
         if len(img.shape) == 2:
-            img = numpy.where(img>threshold*img.max(), img, 0 )
+            img = numpy.where(img > threshold*img.max(), img - threshold*img.max(), 0)
         else:
             img_temp = (img.T - threshold*img.max(-1).max(-1)).T
             zero_coords = numpy.where(img_temp < 0)


### PR DESCRIPTION
Adding argument to centreOfGravity.
This permits to use absolute value in the thresholding and not solely on a faction of the peak value.
The value subtracted to the image and under which pixels are set to 0 is now max(threshold*max_value, minThreshold).