### PR TITLE
Fix missing iteration over the subharmonic matrix

### DIFF
--- a/aotools/turbulence/phasescreen.py
+++ b/aotools/turbulence/phasescreen.py
@@ -75,8 +75,8 @@ def ft_sh_phase_screen(r0, N, delta, L0, l0, FFT=None, seed=None):
                         * numpy.sqrt(PSD_phi)*del_f )
         SH = numpy.zeros((N,N),dtype="complex")
         # loop over frequencies on this grid
-        for i in xrange(0,2):
-            for j in xrange(0,2):
+        for i in xrange(0, 3):
+            for j in xrange(0, 3):
 
                 SH += cn[i,j] * numpy.exp(1j*2*numpy.pi*(fx[i,j]*x+fy[i,j]*y))
 


### PR DESCRIPTION
Hi,
I think there is a little mistake with a big problem in generating phase screens with subharmonics.
In lines 57-61 we create a 3 by 3 frequency matrix. The matrix `cn` (line 73) has the same shape.
But on lines 78-79 with the code `xrange(0,2)` we only iterate over the four elements `(0,0), (0,1), (1,0), (1,1)`, not over the full size of matrix 3 by 3.
This leads to an incorrect calculation of the phase screens. The structure function is very different from what is expected. If we iterate over the entire matrix with code `xrange(0, 3)`, the structure function is much closer to the theoretical one.