### PR TITLE
Make forward/inverse Fourier transforms consistent

### DIFF
--- a/aotools/fouriertransform.py
+++ b/aotools/fouriertransform.py
@@ -21,24 +21,24 @@ def ft(data, delta):
             axes=(-1)) * delta
     return DATA
 
-def ift(DATA, delta_f):
+def ift(data, delta_f):
     """
     Scaled inverse 1-D FFT
 
     Parameters:
-        DATA (ndarray): Data in Fourier Space to transform
+        data (ndarray): Data in Fourier Space to transform
         delta_f (ndarray): Frequency spacing of grid
 
     Returns:
         ndarray: Scaled data in real space
     """
 
-    data = numpy.fft.ifftshift(
+    DATA = numpy.fft.ifftshift(
             numpy.fft.ifft(
                     numpy.fft.ifftshift(DATA, axes=(-1))),
-            axes=(-1)) * len(DATA) * delta_f
+            axes=(-1)) * data.shape[-1] * delta_f
 
-    return data
+    return DATA
 
 
 def ft2(data, delta):
@@ -61,23 +61,25 @@ def ft2(data, delta):
 
     return DATA
 
-def ift2(DATA, delta_f):
+def ift2(data, delta_f):
     """
     Scaled inverse 2-D FFT
 
     Parameters:
-        DATA (ndarray): Data in Fourier Space to transform
+        data (ndarray): Data in Fourier Space to transform
         delta_f (ndarray): Frequency spacing of grid
 
     Returns:
         ndarray: Scaled data in real space
     """
-    N = DATA.shape[0]
-    g = numpy.fft.ifftshift(
+    N = data.shape[-1]
+    DATA = numpy.fft.ifftshift(
             numpy.fft.ifft2(
-                    numpy.fft.ifftshift(DATA))) * (N * delta_f)**2
+                    numpy.fft.ifftshift(data, axes=(-1,-2)
+                    ), axes=(-1,-2))
+            ) * (N * delta_f)**2
 
-    return g
+    return DATA
 
 def rft(data, delta):
     """
@@ -96,24 +98,24 @@ def rft(data, delta):
             axes=(-1)) * delta
     return DATA
 
-def irft(DATA, delta_f):
+def irft(data, delta_f):
     """
     Scaled real inverse 1-D FFT
 
     Parameters:
-        DATA (ndarray): Data in Fourier Space to transform
+        data (ndarray): Data in Fourier Space to transform
         delta_f (ndarray): Frequency spacing of grid
 
     Returns:
         ndarray: Scaled data in real space
     """
 
-    data = numpy.fft.ifftshift(
+    DATA = numpy.fft.ifftshift(
             numpy.fft.irfft(
-                    numpy.fft.ifftshift(DATA, axes=(-1))),
-            axes=(-1)) * len(DATA) * delta_f
+                    numpy.fft.ifftshift(data, axes=(-1))),
+            axes=(-1)) * data.shape[-1] * delta_f
 
-    return data
+    return DATA
 
 def rft2(data, delta):
     """
@@ -134,20 +136,21 @@ def rft2(data, delta):
 
     return DATA
 
-def irft2(DATA, delta_f):
+def irft2(data, delta_f):
     """
     Scaled inverse real 2-D FFT
 
     Parameters:
-        DATA (ndarray): Data in Fourier Space to transform
+        data (ndarray): Data in Fourier Space to transform
         delta_f (ndarray): Frequency spacing of grid
 
     Returns:
         ndarray: Scaled data in real space
     """
-    data = numpy.fft.ifftshift(
+    DATA = numpy.fft.ifftshift(
             numpy.fft.irfft2(
-                    numpy.fft.ifft2(DATA), s=(-1,-2)
+                    numpy.fft.ifftshift(data, axes=(-1,-2)), 
+                    axes=(-1,-2)
                     )
-            ) * (DATA.shape[0]*delta_f)**2
-    return data
+            ) * (data.shape[-1]*delta_f)**2
+    return DATA

--- a/aotools/fouriertransform.py
+++ b/aotools/fouriertransform.py
@@ -77,7 +77,7 @@ def ift2(data, delta_f):
             numpy.fft.ifft2(
                     numpy.fft.ifftshift(data, axes=(-1,-2)
                     ), axes=(-1,-2))
-            ) * (N * delta_f)**2
+            , axes=(-1,-2)) * (N * delta_f)**2
 
     return DATA
 
@@ -147,10 +147,11 @@ def irft2(data, delta_f):
     Returns:
         ndarray: Scaled data in real space
     """
+    N = data.shape[-1]
     DATA = numpy.fft.ifftshift(
             numpy.fft.irfft2(
                     numpy.fft.ifftshift(data, axes=(-1,-2)), 
                     axes=(-1,-2)
-                    )
-            ) * (data.shape[-1]*delta_f)**2
+                    ),
+            axes=(-1,-2)) * (N * delta_f)**2
     return DATA


### PR DESCRIPTION
At the moment the inverse fourier transforms do not work the same as the forward ones. To make it consistent, both types of ft are now taken over the final axis (or axes for 2d transforms). Also made the naming of variables more consistent.

Also fixed a bug in irft2 so it actually works now (maybe?).