### PR TITLE
numpy 1.21 will require an int for factorial

### DIFF
--- a/aotools/functions/zernike.py
+++ b/aotools/functions/zernike.py
@@ -89,13 +89,14 @@ def zernikeRadialFunc(n, m, r):
     """
 
     R = numpy.zeros(r.shape)
+    # Can cast the below to "int", n,m are always *both* either even or odd
     for i in xrange(0, int((n - m) / 2) + 1):
 
         R += numpy.array(r**(n - 2 * i) * (((-1)**(i)) *
                          numpy.math.factorial(n - i)) /
                          (numpy.math.factorial(i) *
-                          numpy.math.factorial(0.5 * (n + m) - i) *
-                          numpy.math.factorial(0.5 * (n - m) - i)),
+                          numpy.math.factorial(int(0.5 * (n + m) - i)) *
+                          numpy.math.factorial(int(0.5 * (n - m) - i))),
                          dtype='float')
     return R
 


### PR DESCRIPTION
This would break some Zernike making functions, which give floats
(even though they are always ints). Now make them ints explicitly.