### PR TITLE
atmospheric params changes

### DIFF
--- a/aotools/turbulence/atmos_conversions.py
+++ b/aotools/turbulence/atmos_conversions.py
@@ -112,7 +112,7 @@ def coherenceTime(cn2, v, lamda=500.E-9, axis=-1):
         coherence time in seconds
     """
     Jv = (cn2*(v**(5./3.))).sum(axis)
-    tau0 = float((Jv**(-3./5.))*0.057*lamda**(6./5.))
+    tau0 = (Jv**(-3./5.))*0.057*lamda**(6./5.)
     return tau0
 
 
@@ -152,7 +152,7 @@ def r0_from_slopes(slopes, wavelength, subapDiam):
 
     r0 = ((0.162 * (wavelength ** 2) * subapDiam ** (-1. / 3)) / slopeVar) ** (3. / 5)
 
-    r0 = float(r0.mean())
+    r0 = r0.mean()
 
     return r0
 

--- a/aotools/turbulence/atmos_conversions.py
+++ b/aotools/turbulence/atmos_conversions.py
@@ -133,6 +133,19 @@ def isoplanaticAngle(cn2, h, lamda=500.E-9, axis=-1):
     return iso
 
 
+def rytov_variance(cn2, h, lamda=500.E-9, axis=-1):
+    """
+    Calculates plane wave Rytov variance from the Cn2 profile
+
+    Parameters:
+        cn2 (numpy.ndarray): Cn2 profile in m^2/3
+        h (numpy.ndarray): Altitude levels of cn2 profile in m
+        lamda (float, optional): wavelength, default 500 nm
+    """
+    k = 2. * numpy.pi / lamda
+    return 2.25 * k**(7./6.) * (cn2*h**(5./6.)).sum(axis)
+
+
 def r0_from_slopes(slopes, wavelength, subapDiam):
     """
     Measures the value of R0 from a set of WFS slopes.

--- a/aotools/turbulence/atmos_conversions.py
+++ b/aotools/turbulence/atmos_conversions.py
@@ -107,6 +107,7 @@ def coherenceTime(cn2, v, lamda=500.E-9, axis=-1):
         cn2 (array): Cn2 profile in m^2/3
         v (array): profile of wind velocity, same altitude scale as cn2 
         lamda : wavelength
+        axis (int, optional): axis over which to integrate (for >1D inputs)
 
     Returns:
         coherence time in seconds
@@ -124,6 +125,7 @@ def isoplanaticAngle(cn2, h, lamda=500.E-9, axis=-1):
         cn2 (array): Cn2 profile in m^2/3
         h (Array): Altitude levels of cn2 profile in m
         lamda : wavelength
+        axis (int, optional): axis over which to integrate (for >1D inputs)
 
     Returns:
         isoplanatic angle in arcseconds
@@ -141,6 +143,10 @@ def rytov_variance(cn2, h, lamda=500.E-9, axis=-1):
         cn2 (numpy.ndarray): Cn2 profile in m^2/3
         h (numpy.ndarray): Altitude levels of cn2 profile in m
         lamda (float, optional): wavelength, default 500 nm
+        axis (int, optional): axis over which to integrate (for >1D inputs)
+
+    Returns:
+        Rytov variance (float)
     """
     k = 2. * numpy.pi / lamda
     return 2.25 * k**(7./6.) * (cn2*h**(5./6.)).sum(axis)

--- a/aotools/turbulence/atmos_conversions.py
+++ b/aotools/turbulence/atmos_conversions.py
@@ -104,7 +104,9 @@ def coherenceTime(cn2, v, lamda=500.E-9, axis=-1):
     Calculates the coherence time from profiles of the Cn2 and wind velocity
 
     Parameters:
-        cn2 (array): Cn2 profile in m^2/3
+        cn2 (array): Cn2 profile in m^2/3. >1D arrays are supported (i.e. multiple
+            profiles), in which case the default assumption is that the turbulent 
+            layers are along the final (-1) axis. 
         v (array): profile of wind velocity, same altitude scale as cn2 
         lamda : wavelength
         axis (int, optional): axis over which to integrate (for >1D inputs)
@@ -122,7 +124,9 @@ def isoplanaticAngle(cn2, h, lamda=500.E-9, axis=-1):
     Calculates the isoplanatic angle from the Cn2 profile
 
     Parameters:
-        cn2 (array): Cn2 profile in m^2/3
+        cn2 (array): Cn2 profile in m^2/3.  >1D arrays are supported (i.e. multiple
+            profiles), in which case the default assumption is that the turbulent 
+            layers are along the final (-1) axis. 
         h (Array): Altitude levels of cn2 profile in m
         lamda : wavelength
         axis (int, optional): axis over which to integrate (for >1D inputs)
@@ -140,7 +144,9 @@ def rytov_variance(cn2, h, lamda=500.E-9, axis=-1):
     Calculates plane wave Rytov variance from the Cn2 profile
 
     Parameters:
-        cn2 (numpy.ndarray): Cn2 profile in m^2/3
+        cn2 (numpy.ndarray): Cn2 profile in m^2/3.  >1D arrays are supported (i.e. multiple
+            profiles), in which case the default assumption is that the turbulent 
+            layers are along the final (-1) axis. 
         h (numpy.ndarray): Altitude levels of cn2 profile in m
         lamda (float, optional): wavelength, default 500 nm
         axis (int, optional): axis over which to integrate (for >1D inputs)

--- a/aotools/turbulence/atmos_conversions.py
+++ b/aotools/turbulence/atmos_conversions.py
@@ -99,7 +99,7 @@ def seeing_to_r0(seeing, lamda=500.E-9):
     return 0.98*lamda/(seeing*numpy.pi/(180.*3600.))
 
 
-def coherenceTime(cn2, v, lamda=500.E-9):
+def coherenceTime(cn2, v, lamda=500.E-9, axis=-1):
     """
     Calculates the coherence time from profiles of the Cn2 and wind velocity
 
@@ -111,12 +111,12 @@ def coherenceTime(cn2, v, lamda=500.E-9):
     Returns:
         coherence time in seconds
     """
-    Jv = (cn2*(v**(5./3.))).sum()
+    Jv = (cn2*(v**(5./3.))).sum(axis)
     tau0 = float((Jv**(-3./5.))*0.057*lamda**(6./5.))
     return tau0
 
 
-def isoplanaticAngle(cn2, h, lamda=500.E-9):
+def isoplanaticAngle(cn2, h, lamda=500.E-9, axis=-1):
     """
     Calculates the isoplanatic angle from the Cn2 profile
 
@@ -128,8 +128,8 @@ def isoplanaticAngle(cn2, h, lamda=500.E-9):
     Returns:
         isoplanatic angle in arcseconds
     """
-    Jh = (cn2*(h**(5./3.))).sum()
-    iso = float(0.057*lamda**(6./5.)*Jh**(-3./5.)*180.*3600./numpy.pi)
+    Jh = (cn2*(h**(5./3.))).sum(axis)
+    iso = 0.057*lamda**(6./5.)*Jh**(-3./5.)*180.*3600./numpy.pi
     return iso
 
 

--- a/test/test_atmos_conversions.py
+++ b/test/test_atmos_conversions.py
@@ -5,19 +5,19 @@ import numpy
 def test_cn2_to_seeing():
     cn2 = 5e-13
     seeing = atmos_conversions.cn2_to_seeing(cn2)
-    assert type(seeing) == float
+    assert isinstance(seeing, float)
 
 
 def test_cn2_to_r0():
     cn2 = 5e-13
     r0 = atmos_conversions.cn2_to_r0(cn2)
-    assert type(r0) == float
+    assert isinstance(r0, (float, numpy.float64))
 
 
 def test_r0_to_seeing():
     r0 = 0.1
     seeing = atmos_conversions.r0_to_seeing(r0)
-    assert type(seeing) == float
+    assert isinstance(seeing, (float, numpy.float64))
 
 
 def test_conversion_consistency():
@@ -45,15 +45,14 @@ def test_coherenceTime():
     cn2 = numpy.array((5e-13, 1e-14))
     v = numpy.array((10, 20))
     tau0 = atmos_conversions.coherenceTime(cn2, v)
-    print(tau0, type(tau0))
-    assert type(tau0) == float
+    assert isinstance(tau0, (float, numpy.float64))
 
 
 def test_isoplanaticAngle():
     cn2 = numpy.array((5e-13, 1e-14))
     h = numpy.array((0., 10000.))
     isoplanatic_angle = atmos_conversions.isoplanaticAngle(cn2, h)
-    assert type(isoplanatic_angle) == float
+    assert isinstance(isoplanatic_angle, (float, numpy.float64))
 
 
 def test_r0_from_slopes():
@@ -61,7 +60,7 @@ def test_r0_from_slopes():
     wavelength = 500e-9
     subapDiam = 0.5
     r0 = atmos_conversions.r0_from_slopes(slopes, wavelength, subapDiam)
-    assert type(r0) == float
+    assert isinstance(r0, (float, numpy.float64))
 
 
 def test_slope_variance_from_r0():
@@ -69,7 +68,7 @@ def test_slope_variance_from_r0():
     wavelength = 500e-9
     subapDiam = 0.5
     variance = atmos_conversions.slope_variance_from_r0(r0, wavelength, subapDiam)
-    assert type(variance) == float
+    assert isinstance(variance, (float, numpy.float64))
 
 
 def test_r0_coversion_consistancy():

--- a/test/test_atmos_conversions.py
+++ b/test/test_atmos_conversions.py
@@ -55,6 +55,13 @@ def test_isoplanaticAngle():
     assert isinstance(isoplanatic_angle, (float, numpy.float64))
 
 
+def test_rytov_variance():
+    cn2 = numpy.array((5e-13, 1e-14))
+    h = numpy.array((0., 10000.))
+    rytov_variance = atmos_conversions.rytov_variance(cn2, h)
+    assert isinstance(rytov_variance, (float, numpy.float64))
+
+
 def test_r0_from_slopes():
     slopes = numpy.random.random((2, 10, 100))
     wavelength = 500e-9


### PR DESCRIPTION
Added an axis parameter to `isoplanaticAngle` and `coherenceTime`, making these funcions compatible with multi-dimensional arrays, with the integration performed over this axis. 

Also added a `rytov_variance` function because it might be useful.

Had to fix some tests for atmos_conversions as well.