### PR TITLE
added exception in the case of KL modes without central obsc

### DIFF
--- a/aotools/functions/karhunenLoeve.py
+++ b/aotools/functions/karhunenLoeve.py
@@ -613,6 +613,8 @@ def make_kl(nmax, dim, ri=0.0, nr=40,
     --------
     gkl_basis, set_pctr, pol2car
     '''
+    if (ri == 0):
+        raise Exception("KL modes generation only works for annular apertures, central obscuration must be > 0!")
 
     npp = int(2 * np.pi * nr)
     if (nr * npp) < (15 * nmax):

--- a/aotools/functions/karhunenLoeve.py
+++ b/aotools/functions/karhunenLoeve.py
@@ -614,7 +614,7 @@ def make_kl(nmax, dim, ri=0.0, nr=40,
     gkl_basis, set_pctr, pol2car
     '''
     if (ri == 0):
-        raise Exception("KL modes generation only works for annular apertures, central obscuration must be > 0!")
+        raise ValueError("KL modes generation only works for annular apertures, ri must be > 0!")
 
     npp = int(2 * np.pi * nr)
     if (nr * npp) < (15 * nmax):


### PR DESCRIPTION
The method used to compute KL modes is only valid for annular apertures, but nothing stops you from using ri=0 (0 central obscuration), resulting in artefacts close to the centre of the modes. Just added a check and exception to make sure this cannot be done.