### PR TITLE
Added ability to rotate generated Zernike modes

### DIFF
--- a/aotools/functions/zernike.py
+++ b/aotools/functions/zernike.py
@@ -1,13 +1,6 @@
 import numpy
 from . import circle
 
-# xrange just "range" in python3.
-# This code means fastest implementation used in 2 and 3
-try:
-    xrange
-except NameError:
-    xrange = range
-
 def phaseFromZernikes(zCoeffs, size, norm="noll", rot=0):
     """
     Creates an array of the sum of zernike polynomials with specified coefficeints
@@ -22,7 +15,7 @@ def phaseFromZernikes(zCoeffs, size, norm="noll", rot=0):
     """
     Zs = zernikeArray(len(zCoeffs), size, norm=norm, rot=rot)
     phase = numpy.zeros((size, size))
-    for z in xrange(len(zCoeffs)):
+    for z in range(len(zCoeffs)):
         phase += Zs[z] * zCoeffs[z]
 
     return phase
@@ -92,7 +85,7 @@ def zernikeRadialFunc(n, m, r):
 
     R = numpy.zeros(r.shape)
     # Can cast the below to "int", n,m are always *both* either even or odd
-    for i in xrange(0, int((n - m) / 2) + 1):
+    for i in range(0, int((n - m) / 2) + 1):
 
         R += numpy.array(r**(n - 2 * i) * (((-1)**(i)) *
                          numpy.math.factorial(n - i)) /
@@ -146,7 +139,7 @@ def zernikeArray(J, N, norm="noll", rot=0):
     try:
         nJ = len(J)
         Zs = numpy.empty((nJ, N, N))
-        for i in xrange(nJ):
+        for i in range(nJ):
             Zs[i] = zernike_noll(J[i], N, rot)
 
     # Else, cast to int and create up to that number
@@ -157,16 +150,16 @@ def zernikeArray(J, N, norm="noll", rot=0):
 
         Zs = numpy.empty((maxJ, N, N))
 
-        for j in xrange(1, maxJ+1):
+        for j in range(1, maxJ+1):
             Zs[j-1] = zernike_noll(j, N, rot)
 
 
     if norm=="p2v":
-        for z in xrange(len(Zs)):
+        for z in range(len(Zs)):
             Zs[z] /= (Zs[z].max()-Zs[z].min())
 
     elif norm=="rms":
-        for z in xrange(len(Zs)):
+        for z in range(len(Zs)):
             # Norm by RMS. Remember only to include circle elements in mean
             Zs[z] /= numpy.sqrt(
                     numpy.sum(Zs[z]**2)/numpy.sum(circle(N/2., N)))


### PR DESCRIPTION
Added the ability to generate rotated Zernike modes with a new keyword (default to 0) in most functions in zernike.py

Also looks like I changed some of the default "range" to "xrange" in line with the python 2 to 3 optimisation in lines 4-11. Can't remember doing this however...so not sure when/where this came in...