### PR TITLE
change constant for coherenceTime and isoplanaticAngle

### DIFF
--- a/aotools/turbulence/atmos_conversions.py
+++ b/aotools/turbulence/atmos_conversions.py
@@ -115,7 +115,7 @@ def coherenceTime(cn2, v, lamda=500.E-9, axis=-1):
         coherence time in seconds
     """
     Jv = (cn2*(v**(5./3.))).sum(axis)
-    tau0 = (Jv**(-3./5.))*0.057*lamda**(6./5.)
+    tau0 = (Jv**(-3./5.))*0.0581*lamda**(6./5.)
     return tau0
 
 
@@ -135,7 +135,7 @@ def isoplanaticAngle(cn2, h, lamda=500.E-9, axis=-1):
         isoplanatic angle in arcseconds
     """
     Jh = (cn2*(h**(5./3.))).sum(axis)
-    iso = 0.057*lamda**(6./5.)*Jh**(-3./5.)*180.*3600./numpy.pi
+    iso = 0.0581*lamda**(6./5.)*Jh**(-3./5.)*180.*3600./numpy.pi
     return iso
 
 


### PR DESCRIPTION
The constant for the `coherenceTime` and `isoplanaticAngle` functions was 0.057, but should be 0.058(1). This was causing a very small (2%) error when these quantities were calculated. Fixed to make consistent with the literature. 