### PR TITLE
fall back to least squares solver when Cholesky fails for infinite phasescreen

### DIFF
--- a/test/test_infinitephasescreen.py
+++ b/test/test_infinitephasescreen.py
@@ -1,4 +1,5 @@
 from aotools.turbulence import infinitephasescreen
+import numpy as np
 
 def testVKInitScreen():
 
@@ -9,6 +10,15 @@ def testVKAddRow():
     scrn = infinitephasescreen.PhaseScreenVonKarman(128, 4./64, 0.2, 50, n_columns=4)
     scrn.add_row()
 
+def testLeastSquaresSolver():
+    airmass = 1.0 / np.cos(30.0 / 180. * np.pi)
+    r0 = 0.9759 * 0.5 / (0.7 * 4.848) * airmass ** (-3. / 5.)
+    r0wavelength = r0 * (500 / 500.0) ** (6. / 5.)
+    screen = infinitephasescreen.PhaseScreenVonKarman(120, 1./120, r0wavelength, 50, 1, n_columns=2)
+    mean_scrn = np.sqrt(np.mean(screen.scrn**2))
+    for i in range(500):
+        screen.add_row()
+    assert(0.5 <= mean_scrn/np.sqrt(np.mean(screen.scrn**2)) <= 1.5)
 
 
 # Test of Kolmogoroc screen


### PR DESCRIPTION
For some parameter settings the Cholesky solver in makeAMatrix failed. In this case I added a least square solver. I also added a test for it.