### PR TITLE
Force use of integers in zernike factorials

### DIFF
--- a/aotools/functions/zernike.py
+++ b/aotools/functions/zernike.py
@@ -91,8 +91,8 @@ def zernikeRadialFunc(n, m, r):
         R += numpy.array(r**(n - 2 * i) * (((-1)**(i)) *
                          math.factorial(n - i)) /
                          (math.factorial(i) *
-                          math.factorial(0.5 * (n + m) - i) *
-                          math.factorial(0.5 * (n - m) - i)),
+                          math.factorial((n + m)//2 - i) *
+                          math.factorial((n - m)//2 - i)),
                          dtype='float')
     return R
 


### PR DESCRIPTION
Something has broken in the factorials used in the zernikes, it doesn't like using floats any more. Fixed to use integers.