### PR TITLE
Fix for phase covariance

### DIFF
--- a/aotools/turbulence/turb.py
+++ b/aotools/turbulence/turb.py
@@ -21,7 +21,7 @@ def phase_covariance(r, r0, L0):
         L0 (float): Outer scale of turbulence in metres
     """
     # Make sure everything is a float to avoid nasty surprises in division!
-    r = numpy.float32(r)
+    r = numpy.float64(r)
     r0 = float(r0)
     L0 = float(L0)
 


### PR DESCRIPTION
The phase_covariance function was converting the input to float32, which was causing numerical precision issues which propagated through to the infinite phase screens (and possibly elsewhere). I have changed this to float64 which seems to resolve this.